### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/Bharadwajdevalraju/java-ds/security/code-scanning/1](https://github.com/Bharadwajdevalraju/java-ds/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow to explicitly define the minimal required permissions. Since the workflow involves publishing packages, it will require `contents: read` (to read repository contents during the build process) and `packages: write` (to publish the package). These permissions can be defined at the root level of the workflow or within the specific job affected (`publish` job).

The `permissions` block will be added to the `publish` job definition, ensuring that the permissions are scoped to the job requiring them.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
